### PR TITLE
moved editing of index.html from willUpload to didBuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
       },
       requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
 
-      willUpload: function(context) {
+      didBuild: function(context) {
         var isEnabled = this.readConfig('enableRevisionTagging');
         if(!isEnabled) {
           return;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "url-join": "0.0.1"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-deploy-revision-data"
   }
 }

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -55,7 +55,7 @@ describe('deploySentry plugin', function() {
     });
 
     assert.equal(typeof plugin.configure, 'function');
-    assert.equal(typeof plugin.willUpload, 'function');
+    assert.equal(typeof plugin.didBuild, 'function');
     assert.equal(typeof plugin.upload, 'function');
     assert.equal(typeof plugin.didDeploy, 'function');
   });
@@ -174,7 +174,7 @@ describe('deploySentry plugin', function() {
     })
   });
 
-  describe('willUpload hook', function() {
+  describe('didBuild hook', function() {
     var plugin, fileSystem, indexFile;
     beforeEach(function() {
       plugin = subject.createDeployPlugin({
@@ -201,7 +201,7 @@ describe('deploySentry plugin', function() {
 
       plugin.beforeHook(context);
       plugin.configure(context);
-      plugin.willUpload(context);
+      plugin.didBuild(context);
       var result = fs.readFileSync('/path/to/fake/dir/index.html', 'utf8');
       assert.notEqual(result.indexOf('<meta name="sentry:revision">'), -1);
     });
@@ -209,7 +209,7 @@ describe('deploySentry plugin', function() {
     it('fills in revision data in the meta-tag', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
-      plugin.willUpload(context);
+      plugin.didBuild(context);
       var result = fs.readFileSync('/path/to/fake/dir/index.html', 'utf8');
       assert.notEqual(result.indexOf('<meta name="sentry:revision" content="'+context.config.deploySentry.revisionKey+'">'), -1);
     });


### PR DESCRIPTION
didBuild makes more sense conceptually, since it is "the thing to do after building" and not "the thing to do before uploading". Ensuring it does run after revision data is available is by requesting the ordering in ember-cli-deploy-revision-data.
