### PR TITLE
Use form-data directly for uploading files

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "form-data": "^1.0.0-rc3",
     "glob": "^5.0.14",
     "request-promise": "^0.4.3",
     "silent-error": "^1.0.0",


### PR DESCRIPTION
allows greater control, circumvents bugs happening on Win64 (https://github.com/request/request/issues/1878)
