### PR TITLE
Add option to unzip gzipped assets since Sentry can't parse gzipped assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ A message that will be displayed after the distDir has been copied to destDir.
 
 *Default:* `/**/*.{js,map}`
 
+### gunzip
+
+If **all** the files matching `filePattern` are gzipped (i.e. you're using [[ember-cli-deploy-gzip](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip)), it will unzip them first before uploading. This is necessary since Sentry cannot parse gzipped artifacts.
+
+*Default:* `false`
+
 ### revisionKey
 
 The revision string that is used to create releases in sentry.
@@ -212,5 +218,5 @@ It works. We use it in production at [Hatchet](https://hatchet.is).
 [4]: https://docs.getsentry.com/on-premise/clients/javascript/sourcemaps/ "Sentry Documentation for Javascript Sourcemaps"
 
 [10]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"
-[11]: https://github.com/zapnito/ember-cli-deploy-build "ember-cli-deploy-build"
-[12]: https://github.com/zapnito/ember-cli-deploy-revision-data "ember-cli-deploy-revision-data"
+[11]: https://github.com/ember-cli-deploy/ember-cli-deploy-build "ember-cli-deploy-build"
+[12]: https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data "ember-cli-deploy-revision-data"

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
             + '/';
         }
       },
-      requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
+      requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey', 'gunzip'],
 
       didBuild: function(context) {
         var isEnabled = this.readConfig('enableRevisionTagging');


### PR DESCRIPTION
In response to #8 , this will add an option for the user to unzip all files matching the `filePattern` before sending them to Sentry.

One issue I'm having though, that I'd like someone to try and replicate, is that when I tried this PR with a pre-existing project, the deployed `index.html` didn't contain the revision tag. When I looked at the build output, I noticed

```
+- didBuild
|  |
|  +- hipchat
|  |
|  +- sentry
|
+- willPrepare
|
+- prepare
|  |
|  +- revision-data
|    - creating revision data using `file-hash`
|    - generated revision data for revision: `c98d1a44e4fbde50254eb3b7f389aecd`
|
+- didPrepare
```

I believe this might be a separate issue, but isn't this flawed? revision-data can't get the hash before didBuild, so should ember-cli-deploy-sentry's didBuild hook be a didPrepare hook? How did this manage to work before?

If I use ember-cli-deploy-sentry 0.2.2, I see this

```
+- didBuild
|  |
|  +- hipchat
|
+- willPrepare
|
+- prepare
|  |
|  +- revision-data
|    - creating revision data using `file-hash`
|    - generated revision data for revision: `c98d1a44e4fbde50254eb3b7f389aecd`
|
+- didPrepare
|
+- willUpload
```

In the original code, didBuild wasn't even called, so how was the revision tag even inserted into index.html??

I think that issue should be cleared before this PR should be considered for a merge.
