### PR TITLE
Use prepare hook instead of didBuild hook to catch revision data

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
       },
       requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
 
-      didBuild: function(context) {
+      prepare: function(context) {
         var isEnabled = this.readConfig('enableRevisionTagging');
         if(!isEnabled) {
           return;

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -55,7 +55,7 @@ describe('deploySentry plugin', function() {
     });
 
     assert.equal(typeof plugin.configure, 'function');
-    assert.equal(typeof plugin.didBuild, 'function');
+    assert.equal(typeof plugin.prepare, 'function');
     assert.equal(typeof plugin.upload, 'function');
     assert.equal(typeof plugin.didDeploy, 'function');
   });
@@ -174,7 +174,7 @@ describe('deploySentry plugin', function() {
     })
   });
 
-  describe('didBuild hook', function() {
+  describe('prepare hook', function() {
     var plugin, fileSystem, indexFile;
     beforeEach(function() {
       plugin = subject.createDeployPlugin({
@@ -201,7 +201,7 @@ describe('deploySentry plugin', function() {
 
       plugin.beforeHook(context);
       plugin.configure(context);
-      plugin.didBuild(context);
+      plugin.prepare(context);
       var result = fs.readFileSync('/path/to/fake/dir/index.html', 'utf8');
       assert.notEqual(result.indexOf('<meta name="sentry:revision">'), -1);
     });
@@ -209,7 +209,7 @@ describe('deploySentry plugin', function() {
     it('fills in revision data in the meta-tag', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
-      plugin.didBuild(context);
+      plugin.prepare(context);
       var result = fs.readFileSync('/path/to/fake/dir/index.html', 'utf8');
       assert.notEqual(result.indexOf('<meta name="sentry:revision" content="'+context.config.deploySentry.revisionKey+'">'), -1);
     });


### PR DESCRIPTION
Fixes #10, issues mentioned in #9 
Using `prepare` instead of `didPrepare` because we decided to run with the dependency ordering config in `package.json` as follows:

``` javascript
"ember-addon": {
  "configPath": "tests/dummy/config",
  "after": "ember-cli-deploy-revision-data"
}
```
