### PR TITLE
reorganizes index.js with more promises and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Enable adding a meta tag with the current revisionKey into the head of your `ind
 
 ### replaceFiles
 
-At deploy-time, the plugin will check your Sentry instance for an existing release under the current `revisionKey`. If a release is found and this is set to `true`, all existing files for the matching release will be deleted before the current build's files are uploaded to Sentry.
+At deploy-time, the plugin will check your Sentry instance for an existing release under the current `revisionKey`. If a release is found and this is set to `true`, all existing files for the matching release will be deleted before the current build's files are uploaded to Sentry. If this is set to `false`, the files on Sentry will remain untouched and the just-built files will not be uploaded. 
 
 *Default* false
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Enable adding a meta tag with the current revisionKey into the head of your `ind
 
 At deploy-time, the plugin will check your Sentry instance for an existing release under the current `revisionKey`. If a release is found and this is set to `true`, all existing files for the matching release will be deleted before the current build's files are uploaded to Sentry. If this is set to `false`, the files on Sentry will remain untouched and the just-built files will not be uploaded. 
 
-*Default* false
+*Default* true
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Enable adding a meta tag with the current revisionKey into the head of your `ind
 
 *Default* true
 
+### replaceFiles
+
+At deploy-time, the plugin will check your Sentry instance for an existing release under the current `revisionKey`. If a release is found and this is set to `true`, all existing files for the matching release will be deleted before the current build's files are uploaded to Sentry.
+
+*Default* false
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ module.exports = {
           },
         })
       },
-      _logFiles: function logFiles(response) {
+      logFiles: function logFiles(response) {
         this.log('Files known to sentry for this release', { verbose: true });
         response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }) }, this);
       },

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
             + this.readConfig('revisionKey')
             + '/';
         },
-        replaceFiles: false
+        replaceFiles: true
       },
       requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
 

--- a/index.js
+++ b/index.js
@@ -102,23 +102,23 @@ module.exports = {
         });
       },
       handleExistingRelease: function handleExistingRelease(response) {
-        this.log('Release ' + response.version + ' exists.');
-        this.log('Retrieving release files.');
+        this.log('Release ' + response.version + ' exists.', {verbose: true});
+        this.log('Retrieving release files.', {verbose: true});
         return this._getReleaseFiles().then(function(response) {
           if (this.readConfig('replaceFiles')) {
-            this.log('Replacing files.');
+            this.log('Replacing files.', {verbose: true});
             return Promise.all(response.map(this._deleteFile, this))
               .then(this.doUpload.bind(this))
               .then(this.logFiles.bind(this, response));
           } else {
-            this.log('Leaving files alone.');
+            this.log('Leaving files alone.', {verbose: true});
             return this.logFiles(response);
           }
         }.bind(this));
       },
       createRelease: function createRelease(error) {
         if (error.statusCode === 404) {
-          this.log('Release does not exist. Creating.');
+          this.log('Release does not exist. Creating.', {verbose: true});
         } else if (error.statusCode === 400) {
           this.log('Bad Request. Not Continuing');
           return Promise.resolve(error.message);
@@ -148,7 +148,7 @@ module.exports = {
           .then(this._uploadFileList.bind(this));
       },
       _getFilesToUpload: function getFilesToUpload() {
-        this.log('Generating file list for upload');
+        this.log('Generating file list for upload', {verbose: true});
         var dir = this.readConfig('distDir');
         var filePattern = this.readConfig('filePattern');
         var pattern = path.join(dir, filePattern);
@@ -168,7 +168,7 @@ module.exports = {
         });
       },
       _uploadFileList: function uploadFileList(files) {
-        this.log('Beginning upload.');
+        this.log('Beginning upload.', {verbose: true});
         return Promise.all(files.map(throat(5, this._uploadFile.bind(this))))
           .then(this._getReleaseFiles.bind(this));
       },
@@ -215,7 +215,7 @@ module.exports = {
         });
       },
       _deleteFile: function deleteFile(file) {
-        this.log('Deleting ' + file.name);
+        this.log('Deleting ' + file.name, {verbose: true});
         return request({
           uri: urljoin(this.releaseUrl, 'files/', file.id, '/'),
           method: 'DELETE',

--- a/index.js
+++ b/index.js
@@ -124,12 +124,15 @@ module.exports = {
           },
           resolveWithFullResponse: true
         })
-        .then(this._getFilesToUpload.bind(this))
-        .then(this._uploadFileList.bind(this))
+        .then(this.doUpload.bind(this))
         .catch(function(err){
           console.error(err);
           throw new SilentError('Creating release failed');
         });
+      },
+      doUpload: function doUpload() {
+        return this._getFilesToUpload()
+          .then(this._uploadFileList.bind(this));
       },
       _getFilesToUpload: function getFilesToUpload() {
         var dir = this.readConfig('distDir');

--- a/index.js
+++ b/index.js
@@ -106,8 +106,10 @@ module.exports = {
           if (this.readConfig('replaceFiles')) {
             return Promise.all(response.map(this._deleteFile, this))
               .then(this.doUpload.bind(this))
+              .then(this.logFiles.bind(this, response))
           } else {
             this.log('Leaving files alone.');
+            return this.logFiles(response);
           }
         });
       },
@@ -132,6 +134,7 @@ module.exports = {
           resolveWithFullResponse: true
         })
         .then(this.doUpload.bind(this))
+        .then(this.logFiles.bind(this))
         .catch(function(err){
           console.error(err);
           throw new SilentError('Creating release failed');

--- a/index.js
+++ b/index.js
@@ -102,8 +102,10 @@ module.exports = {
       },
       handleExistingRelease: function handleExistingRelease(response) {
         this.log('Release ' + response.version + ' exists.');
+        this.log('Retrieving release files.');
         this._getReleaseFiles().then(function(response) {
           if (this.readConfig('replaceFiles')) {
+            this.log('Replacing files.');
             return Promise.all(response.map(this._deleteFile, this))
               .then(this.doUpload.bind(this))
               .then(this.logFiles.bind(this, response))
@@ -145,6 +147,7 @@ module.exports = {
           .then(this._uploadFileList.bind(this));
       },
       _getFilesToUpload: function getFilesToUpload() {
+        this.log('Generating file list for upload');
         var dir = this.readConfig('distDir');
         var filePattern = this.readConfig('filePattern');
         var pattern = path.join(dir, filePattern);
@@ -164,6 +167,7 @@ module.exports = {
         });
       },
       _uploadFileList: function uploadFileList(files) {
+        this.log('Beginning upload.');
         return Promise.all(files.map(throat(5, this._uploadFile.bind(this))))
           .then(this._getReleaseFiles.bind(this));
       },

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports = {
       handleExistingRelease: function handleExistingRelease(response) {
         this.log('Release ' + response.version + ' exists.');
         this.log('Retrieving release files.');
-        this._getReleaseFiles().then(function(response) {
+        return this._getReleaseFiles().then(function(response) {
           if (this.readConfig('replaceFiles')) {
             this.log('Replacing files.');
             return Promise.all(response.map(this._deleteFile, this))

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ module.exports = {
             + '/releases/'
             + this.readConfig('revisionKey')
             + '/';
-        }
+        },
+        replaceFiles: false
       },
       requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
 

--- a/index.js
+++ b/index.js
@@ -70,40 +70,70 @@ module.exports = {
         fs.writeFileSync(indexPath, index);
       },
 
-      _createRelease: function createRelease(sentrySettings) {
-        var url = urljoin(sentrySettings.url, '/api/0/projects/', sentrySettings.organizationSlug,  sentrySettings.projectSlug, '/releases/');
+      upload: function(/* context */) {
+        this.sentrySettings = {
+          url: this.readConfig('sentryUrl'),
+          publicUrl: this.readConfig('publicUrl'),
+          organizationSlug: this.readConfig('sentryOrganizationSlug'),
+          projectSlug: this.readConfig('sentryProjectSlug'),
+          apiKey: this.readConfig('sentryApiKey'),
+          release: this.readConfig('revisionKey')
+        };
+        this.baseUrl = urljoin(this.sentrySettings.url, '/api/0/projects/', this.sentrySettings.organizationSlug, this.sentrySettings.projectSlug, '/releases/');
+        this.releaseUrl = urljoin(this.baseUrl, this.sentrySettings.release, '/');
+
+        if(!this.sentrySettings.release) {
+          throw new SilentError('revisionKey setting is not available, either provide it manually or make sure the ember-cli-deploy-revision-data plugin is loaded');
+        }
+
+        return this.doesReleaseExist(this.releaseUrl)
+          .then(this.handleExistingRelease.bind(this))
+          .catch(this.createRelease.bind(this));
+      },
+
+      doesReleaseExist: function(releaseUrl) {
+        return request({
+          uri: releaseUrl,
+          auth: {
+            user: this.sentrySettings.apiKey
+          },
+          json: true,
+        });
+      },
+      handleExistingRelease: function handleExistingRelease(response) {
+        this.log('Release ' + response.version + ' exists.');
+        return this._getReleaseFiles();
+      },
+      createRelease: function createRelease(error) {
+        if (error.statusCode === 404) {
+          this.log('Release does not exist. Creating.');
+        } else if (error.statusCode === 400) {
+          this.log('Bad Request. Not Continuing');
+          return Promise.resolve(error.message);
+        }
 
         return request({
-          uri: url,
+          uri: this.baseUrl,
           method: 'POST',
           auth: {
-            user: sentrySettings.apiKey
+            user: this.sentrySettings.apiKey
           },
           json: true,
           body: {
-            version: sentrySettings.release
+            version: this.sentrySettings.release
           },
           resolveWithFullResponse: true
+        })
+        .then(this._getFilesToUpload.bind(this))
+        .then(this._uploadFileList.bind(this))
+        .catch(function(err){
+          console.error(err);
+          throw new SilentError('Creating release failed');
         });
       },
-      _deleteRelease: function createRelease(sentrySettings) {
-        var url = urljoin(sentrySettings.url, '/api/0/projects/', sentrySettings.organizationSlug,  sentrySettings.projectSlug, '/releases/', sentrySettings.release) + '/';
-
-        return request({
-          uri: url,
-          method: 'DELETE',
-          auth: {
-            user: sentrySettings.apiKey
-          },
-          json: true,
-          body: {
-            version: sentrySettings.release
-          },
-          resolveWithFullResponse: true
-        });
-      },
-
-      _getUploadFiles: function getUploadFiles(dir, filePattern) {
+      _getFilesToUpload: function getFilesToUpload() {
+        var dir = this.readConfig('distDir');
+        var filePattern = this.readConfig('filePattern');
         var pattern = path.join(dir, filePattern);
         return new Promise(function(resolve, reject) {
           // options is optional
@@ -120,13 +150,18 @@ module.exports = {
           });
         });
       },
-
-      _uploadFile: function uploadFile(sentrySettings, distDir, filePath) {
-        var sentry_url = sentrySettings.url;
-        var urlPath = urljoin('/api/0/projects/', sentrySettings.organizationSlug,  sentrySettings.projectSlug, '/releases/', sentrySettings.release, '/files/');
+      _uploadFileList: function uploadFileList(files) {
+        return Promise.all(files.map(throat(5, this._uploadFile.bind(this))))
+          .then(this._getReleaseFiles.bind(this));
+      },
+      _uploadFile: function uploadFile(filePath) {
+        var sentrySettings = this.sentrySettings;
+        var distDir = this.readConfig('distDir');
+        var sentry_url = this.sentrySettings.url;
+        var urlPath = urljoin(this.releaseUrl, 'files/');
         var host = url.parse(sentry_url).host
         var formData = new FormData();
-        formData.append('name', urljoin(sentrySettings.publicUrl, filePath));
+        formData.append('name', urljoin(this.sentrySettings.publicUrl, filePath));
 
         var fileName = path.join(distDir, filePath);
         var fileSize = fs.statSync(fileName)["size"];
@@ -152,59 +187,19 @@ module.exports = {
           });
         });
       },
-
-      _getReleaseFiles: function getReleaseFiles(sentrySettings) {
-        var url = urljoin(sentrySettings.url, '/api/0/projects/', sentrySettings.organizationSlug,  sentrySettings.projectSlug, '/releases/', sentrySettings.release, '/files') + '/';
+      _getReleaseFiles: function getReleaseFiles() {
         return request({
-          uri: url,
+          uri: urljoin(this.releaseUrl, 'files/'),
           auth: {
-            user: sentrySettings.apiKey
+            user: this.sentrySettings.apiKey
           },
-          json: true,
-          body: {
-            version: sentrySettings.release
-          }
-        });
+          json: true
+        }).then(function(response) {
+          this.log('Files known to sentry for this release', { verbose: true });
+          response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }) }, this);
+        }.bind(this));
       },
 
-      upload: function(/* context */) {
-        var plugin = this;
-        var distDir = this.readConfig('distDir');
-        var sentrySettings = {
-          url: plugin.readConfig('sentryUrl'),
-          publicUrl: plugin.readConfig('publicUrl'),
-          organizationSlug: plugin.readConfig('sentryOrganizationSlug'),
-          projectSlug: plugin.readConfig('sentryProjectSlug'),
-          apiKey: plugin.readConfig('sentryApiKey'),
-          release: plugin.readConfig('revisionKey')
-        };
-        var filePattern = this.readConfig('filePattern');
-
-        if(!sentrySettings.release) {
-          throw new SilentError('revisionKey setting is not available, either provide it manually or make sure the ember-cli-deploy-revision-data plugin is loaded');
-        }
-        return this._deleteRelease(sentrySettings).then(function() {}, function() {}).then(function() {
-          return plugin._createRelease(sentrySettings).then(function(response) {
-            return plugin._getUploadFiles(distDir, filePattern).then(function(files) {
-              var uploader = function(f){
-                return plugin._uploadFile(sentrySettings, distDir, f);
-              };
-
-              return Promise.all(files.map(throat(5, uploader))).then(function() {
-                return plugin._getReleaseFiles(sentrySettings);
-              }).then(function(response) {
-                plugin.log('Files known to sentry for this release', { verbose: true });
-                for (var i=0 ; i<response.length ; i++) {
-                  plugin.log('✔  ' + response[i].name, { verbose: true });
-                }
-              });
-            });
-          }, function(err){
-            console.error(err);
-            throw new SilentError('Creating release failed');
-          });
-        });
-      },
       didDeploy: function(/* context */){
         var didDeployMessage = this.readConfig('didDeployMessage');
         if (didDeployMessage) {

--- a/index.js
+++ b/index.js
@@ -108,11 +108,11 @@ module.exports = {
           if (this.readConfig('replaceFiles')) {
             this.log('Replacing files.', {verbose: true});
             return Promise.all(response.map(this._deleteFile, this))
-              .then(this.doUpload.bind(this))
-              .then(this.logFiles.bind(this, response));
+              .then(this._doUpload.bind(this))
+              .then(this._logFiles.bind(this, response));
           } else {
             this.log('Leaving files alone.', {verbose: true});
-            return this.logFiles(response);
+            return this._logFiles(response);
           }
         }.bind(this));
       },
@@ -136,14 +136,14 @@ module.exports = {
           },
           resolveWithFullResponse: true
         })
-        .then(this.doUpload.bind(this))
-        .then(this.logFiles.bind(this))
+        .then(this._doUpload.bind(this))
+        .then(this._logFiles.bind(this))
         .catch(function(err){
           console.error(err);
           throw new SilentError('Creating release failed');
         });
       },
-      doUpload: function doUpload() {
+      _doUpload: function doUpload() {
         return this._getFilesToUpload()
           .then(this._uploadFileList.bind(this));
       },
@@ -224,7 +224,7 @@ module.exports = {
           },
         });
       },
-      logFiles: function logFiles(response) {
+      _logFiles: function logFiles(response) {
         this.log('Files known to sentry for this release', { verbose: true });
         response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }); }, this);
       },

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = {
             this.log('Leaving files alone.');
             return this.logFiles(response);
           }
-        });
+        }.bind(this));
       },
       createRelease: function createRelease(error) {
         if (error.statusCode === 404) {

--- a/index.js
+++ b/index.js
@@ -197,10 +197,11 @@ module.exports = {
             user: this.sentrySettings.apiKey
           },
           json: true
-        }).then(function(response) {
-          this.log('Files known to sentry for this release', { verbose: true });
-          response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }) }, this);
-        }.bind(this));
+        });
+      },
+      _logFiles: function logFiles(response) {
+        this.log('Files known to sentry for this release', { verbose: true });
+        response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }) }, this);
       },
 
       didDeploy: function(/* context */){

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var url = require('url');
 module.exports = {
   name: 'ember-cli-deploy-sentry',
 
-  contentFor: function(type, config) {
+  contentFor: function(type/*, config*/) {
     if (type === 'head-footer') {
       return '<meta name="sentry:revision"></meta>';
     }
@@ -36,7 +36,7 @@ module.exports = {
         },
         enableRevisionTagging: true,
 
-        didDeployMessage: function(context){
+        didDeployMessage: function(/*context*/){
           return "Uploaded sourcemaps to sentry release: "
             + this.readConfig('sentryUrl')
             + '/'
@@ -66,7 +66,7 @@ module.exports = {
         // getConfig('revision patterns') on context.distFiles
         var indexPath = path.join(context.distDir, "index.html");
         var index = fs.readFileSync(indexPath, 'utf8');
-        var index = index.replace('<meta name="sentry:revision">',
+        index = index.replace('<meta name="sentry:revision">',
                                   '<meta name="sentry:revision" content="'+revisionKey+'">');
         fs.writeFileSync(indexPath, index);
       },
@@ -109,7 +109,7 @@ module.exports = {
             this.log('Replacing files.');
             return Promise.all(response.map(this._deleteFile, this))
               .then(this.doUpload.bind(this))
-              .then(this.logFiles.bind(this, response))
+              .then(this.logFiles.bind(this, response));
           } else {
             this.log('Leaving files alone.');
             return this.logFiles(response);
@@ -177,7 +177,7 @@ module.exports = {
         var distDir = this.readConfig('distDir');
         var sentry_url = this.sentrySettings.url;
         var urlPath = urljoin(this.releaseUrl, 'files/');
-        var host = url.parse(sentry_url).host
+        var host = url.parse(sentry_url).host;
         var formData = new FormData();
         formData.append('name', urljoin(this.sentrySettings.publicUrl, filePath));
 
@@ -222,11 +222,11 @@ module.exports = {
           auth: {
             user: this.sentrySettings.apiKey
           },
-        })
+        });
       },
       logFiles: function logFiles(response) {
         this.log('Files known to sentry for this release', { verbose: true });
-        response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }) }, this);
+        response.forEach(function(file) { this.log('✔  ' + file.name, { verbose: true }); }, this);
       },
 
       didDeploy: function(/* context */){

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -121,7 +121,7 @@ describe('deploySentry plugin', function() {
           return previous;
         }, []);
 
-        assert.equal(messages.length, 4);
+        assert.equal(messages.length, 5);
       });
 
       it('adds default config to the config object', function() {
@@ -145,6 +145,7 @@ describe('deploySentry plugin', function() {
         context.config.deploySentry["filePattern"] = "/**/*.{js,map}";
         context.config.deploySentry["enableRevisionTagging"] = false;
         context.config.deploySentry["didDeployMessage"] = "ok";
+        context.config.deploySentry["replaceFiles"] = true;
       });
 
       it('does not warn about missing optional config', function() {


### PR DESCRIPTION
Hi

Sorry this is all in one commit, but it grew out of a spike I did in order to fix #17.

[Sentry servers will return a 400 response](https://github.com/getsentry/sentry/blob/481b4b9d2365749c7b8fcf55d5aa66ee5210ab93/src/sentry/api/endpoints/release_details.py#L174) to `DELETE` requests if there are actives issues on the requested release version. 

```
{ detail: "This release is referenced by active issues and cannot be removed."}
```

Since `_deleteRelease` wasn't handling errors, `_createRelease` would reliably fail in these scenarios, since `POST` requests with existing version numbers would also return 400 errors, which would ultimately abort an entire deploy.

The general idea behind this patch is to allow a deploy to complete regardless if a release version exists in Sentry or not. Most of the time the release numbers are unique, whether generated via version numbers or hashes or both, so I'm not sure why there was an attempt to delete an existing release to begin with. It's possible I'm missing a use-case, but one thing this patch does is to remove that step from the code.

The flow goes like this:

```
* Make a request for a release with the given revision key for this deploy
* If that revision key exists, i.e. on 200, simply list the files known to sentry and finish
* If that revision key does not exist, i.e. on a 404, create a new release, more or less following your original flow
```

This also refactors a lot of the code to make it more "promise-like", so that we can avoid the "callback triangle".

Also this tweaks the `getReleaseFiles` method so that it outputs the filenames instead of `[object Object]`.
