### PR TITLE
Update to use bearer tokens, per current Sentry auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ ENV.sentry = {
   sentryUrl: 'https://sentry.your.awesome.site',
   sentryOrganizationSlug: 'AwesomeOrg',
   sentryProjectSlug: 'AwesomeProject',
-  sentryApiKey: 'awesomeApiKey'
+  auth: {
+    bearer: 'awesomeApiKey'  // Or user: 'awesomeApiKey', as appropriate
+  }
 }
 ```
 - Integrate [raven-js][2] in your page
@@ -108,9 +110,11 @@ You can specify this in project settings in sentry.
 
 *Required*
 
-### sentryApiKey
+### auth
 
-An api key you can create in your organization settings. Make sure it has the `project:write` privilege.
+An object with your api key, either under `bearer`, if you are uploading to the current Sentry API, or `user` if you are using an older API.
+
+You can create the api key in your organization settings. Make sure it has the `project:write` privilege.
 
 *Required*
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ ENV.sentry = {
   sentryUrl: 'https://sentry.your.awesome.site',
   sentryOrganizationSlug: 'AwesomeOrg',
   sentryProjectSlug: 'AwesomeProject',
-  auth: {
-    bearer: 'awesomeApiKey'  // Or user: 'awesomeApiKey', as appropriate
-  }
+  // One of:
+  apiKey: 'awesomeApiKey',
+  // or
+  bearerApiKey: 'awesomeApiKey'
 }
 ```
 - Integrate [raven-js][2] in your page
@@ -110,9 +111,9 @@ You can specify this in project settings in sentry.
 
 *Required*
 
-### auth
+### apiKey _or_ bearerApiKey
 
-An object with your api key, either under `bearer`, if you are uploading to the current Sentry API, or `user` if you are using an older API.
+Either an HTTP Basic Auth username, or a bearer token. If you are uploading to the current Sentry API, use the latter. Use the former if you are using an older API.
 
 You can create the api key in your organization settings. Make sure it has the `project:write` privilege.
 

--- a/index.js
+++ b/index.js
@@ -95,9 +95,7 @@ module.exports = {
       doesReleaseExist: function(releaseUrl) {
         return request({
           uri: releaseUrl,
-          auth: {
-            bearer: this.sentrySettings.apiKey
-          },
+          auth: this.sentrySettings.auth,
           json: true,
         });
       },
@@ -127,9 +125,7 @@ module.exports = {
         return request({
           uri: this.baseUrl,
           method: 'POST',
-          auth: {
-            bearer: this.sentrySettings.apiKey
-          },
+          auth: this.sentrySettings.auth,
           json: true,
           body: {
             version: this.sentrySettings.release
@@ -208,9 +204,7 @@ module.exports = {
       _getReleaseFiles: function getReleaseFiles() {
         return request({
           uri: urljoin(this.releaseUrl, 'files/'),
-          auth: {
-            bearer: this.sentrySettings.apiKey
-          },
+          auth: this.sentrySettings.auth,
           json: true
         });
       },
@@ -219,9 +213,7 @@ module.exports = {
         return request({
           uri: urljoin(this.releaseUrl, 'files/', file.id, '/'),
           method: 'DELETE',
-          auth: {
-            bearer: this.sentrySettings.apiKey
-          },
+          auth: this.sentrySettings.auth
         });
       },
       _logFiles: function logFiles(response) {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = {
         return request({
           uri: releaseUrl,
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true,
         });
@@ -128,7 +128,7 @@ module.exports = {
           uri: this.baseUrl,
           method: 'POST',
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true,
           body: {
@@ -209,7 +209,7 @@ module.exports = {
         return request({
           uri: urljoin(this.releaseUrl, 'files/'),
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true
         });
@@ -220,7 +220,7 @@ module.exports = {
           uri: urljoin(this.releaseUrl, 'files/', file.id, '/'),
           method: 'DELETE',
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
         });
       },

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ module.exports = {
           organizationSlug: this.readConfig('sentryOrganizationSlug'),
           projectSlug: this.readConfig('sentryProjectSlug'),
           apiKey: this.readConfig('sentryApiKey'),
+          bearerApiKey: this.readConfig('sentryBearerApiKey'),
           release: this.readConfig('revisionKey')
         };
         this.baseUrl = urljoin(this.sentrySettings.url, '/api/0/projects/', this.sentrySettings.organizationSlug, this.sentrySettings.projectSlug, '/releases/');
@@ -92,10 +93,19 @@ module.exports = {
           .catch(this.createRelease.bind(this));
       },
 
+      generateAuth: function() {
+        var apiKey = this.sentrySettings.apiKey;
+        var bearerApiKey = this.sentrySettings.bearerApiKey;
+        if (bearerApiKey !== undefined) {
+          return { bearer: bearerApiKey };
+        }
+        return { user: apiKey };
+      },
+
       doesReleaseExist: function(releaseUrl) {
         return request({
           uri: releaseUrl,
-          auth: this.sentrySettings.auth,
+          auth: this.generateAuth(),
           json: true,
         });
       },
@@ -204,7 +214,7 @@ module.exports = {
       _getReleaseFiles: function getReleaseFiles() {
         return request({
           uri: urljoin(this.releaseUrl, 'files/'),
-          auth: this.sentrySettings.auth,
+          auth: this.generateAuth(),
           json: true
         });
       },
@@ -213,7 +223,7 @@ module.exports = {
         return request({
           uri: urljoin(this.releaseUrl, 'files/', file.id, '/'),
           method: 'DELETE',
-          auth: this.sentrySettings.auth
+          auth: this.generateAuth(),
         });
       },
       _logFiles: function logFiles(response) {


### PR DESCRIPTION
Uploading sourcemaps to Sentry was failing, due to Sentry expecting a bearer token. I've adjusted the auth options accordingly.

_Per the tradition of my people, every pull request should come with a cute animal picture:_

![high five](https://s-media-cache-ak0.pinimg.com/236x/c1/15/e4/c115e4d4b8eec90ee22a1875ddc18c80.jpg)
