### PR TITLE
Fix config for (bearer)apiKey in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ ENV.sentry = {
   sentryOrganizationSlug: 'AwesomeOrg',
   sentryProjectSlug: 'AwesomeProject',
   // One of:
-  apiKey: 'awesomeApiKey',
+  sentryApiKey: 'awesomeApiKey',
   // or
-  bearerApiKey: 'awesomeApiKey'
+  sentryBearerApiKey: 'awesomeApiKey'
 }
 ```
 - Integrate [raven-js][2] in your page


### PR DESCRIPTION
The config keys should actually be `sentryApiKey` or `sentryBearerApiKey`: https://github.com/dschmidt/ember-cli-deploy-sentry/blob/master/index.js#L80-L81
