### PR TITLE
Fix deploy message not being able to call readConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,18 +33,6 @@ module.exports = {
           return context.revisionData && context.revisionData.revisionKey;
         },
         enableRevisionTagging: true,
-
-        didDeployMessage: function(/*context*/){
-          return "Uploaded sourcemaps to sentry release: "
-            + this.readConfig('sentryUrl')
-            + '/'
-            + this.readConfig('sentryOrganizationSlug')
-            + '/'
-            + this.readConfig('sentryProjectSlug')
-            + '/releases/'
-            + this.readConfig('revisionKey')
-            + '/';
-        },
         replaceFiles: true
       },
       requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
@@ -213,10 +201,17 @@ module.exports = {
       },
 
       didDeploy: function(/* context */){
-        var didDeployMessage = this.readConfig('didDeployMessage');
-        if (didDeployMessage) {
-          this.log(didDeployMessage);
-        }
+        var deployMessage = "Uploaded sourcemaps to sentry release: "
+          + this.readConfig('sentryUrl')
+          + '/'
+          + this.readConfig('sentryOrganizationSlug')
+          + '/'
+          + this.readConfig('sentryProjectSlug')
+          + '/releases/'
+          + this.readConfig('revisionKey')
+          + '/';
+
+        this.log(deployMessage);
       }
     });
     return new DeployPlugin();

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -121,7 +121,7 @@ describe('deploySentry plugin', function() {
           return previous;
         }, []);
 
-        assert.equal(messages.length, 5);
+        assert.equal(messages.length, 4);
       });
 
       it('adds default config to the config object', function() {
@@ -130,7 +130,6 @@ describe('deploySentry plugin', function() {
         assert.isDefined(context.config.deploySentry.distDir);
         assert.isDefined(context.config.deploySentry.filePattern);
         assert.isDefined(context.config.deploySentry.enableRevisionTagging);
-        assert.isDefined(context.config.deploySentry.didDeployMessage);
       });
     });
 
@@ -144,7 +143,6 @@ describe('deploySentry plugin', function() {
         context.config.deploySentry["distDir"] = "dist/dir";
         context.config.deploySentry["filePattern"] = "/**/*.{js,map}";
         context.config.deploySentry["enableRevisionTagging"] = false;
-        context.config.deploySentry["didDeployMessage"] = "ok";
         context.config.deploySentry["replaceFiles"] = true;
       });
 


### PR DESCRIPTION
New released of `ember-cli-deploy-plugin-base` broke what we understood for `this` in the context of `createDeployPlugin`, so we have to resort to reading config somewhere else (or using their `pluginHelper`).

(if you're happy with the code, could you please cut a release? - as this is breaking pipelines)