### PR TITLE
Fix version of ember-cli-deploy-plugin to 0.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-deploy-plugin": "^0.2.0",
+    "ember-cli-deploy-plugin": "0.2.8",
     "glob": "^5.0.14",
     "request-promise": "^0.4.3",
     "silent-error": "^1.0.0",


### PR DESCRIPTION
Fix version of [ember-cli-deploy-plugin](https://github.com/ember-cli-deploy/ember-cli-deploy-plugin) because of https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/pull/15 introduced in 0.2.9 as deploys now fail with the error `TypeError: this.readConfig is not a function`.

This is a fix to get deploys to work until it's been fixed to work ember-cli-deploy-plugin 0.2.9.