### PR TITLE
Remove legacy API token and require bearer token

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,13 @@ module.exports = {
         enableRevisionTagging: true,
         replaceFiles: true
       },
-      requiredConfig: ['publicUrl', 'sentryUrl', 'sentryOrganizationSlug', 'sentryProjectSlug', 'sentryApiKey', 'revisionKey'],
+      requiredConfig: [
+        'publicUrl',
+        'sentryUrl',
+        'sentryOrganizationSlug',
+        'sentryProjectSlug',
+        'sentryBearerApiKey',
+        'revisionKey'],
 
       prepare: function(context) {
         var isEnabled = this.readConfig('enableRevisionTagging');
@@ -63,7 +69,6 @@ module.exports = {
           publicUrl: this.readConfig('publicUrl'),
           organizationSlug: this.readConfig('sentryOrganizationSlug'),
           projectSlug: this.readConfig('sentryProjectSlug'),
-          apiKey: this.readConfig('sentryApiKey'),
           bearerApiKey: this.readConfig('sentryBearerApiKey'),
           release: this.readConfig('revisionKey')
         };
@@ -80,12 +85,7 @@ module.exports = {
       },
 
       generateAuth: function() {
-        var apiKey = this.sentrySettings.apiKey;
-        var bearerApiKey = this.sentrySettings.bearerApiKey;
-        if (bearerApiKey !== undefined) {
-          return { bearer: bearerApiKey };
-        }
-        return { user: apiKey };
+        return { bearer: this.sentrySettings.bearerApiKey };
       },
 
       doesReleaseExist: function(releaseUrl) {


### PR DESCRIPTION
Support for bearer tokens was added to the plugin, since that is required for modern Sentry support. But `sentryApiToken` is still required, which makes no sense. There are about 6 forks of the repo solely for the purpose of making this work.

I have removed legacy `sentryApiToken` support completely, requiring `sentryBearerApiToken` instead. I recommend releasing this with a major version bump, so we can move ahead. Those using the old version of Sentry will need to stick with their old version of the plugin, or update and get a new token from Sentry.