### PR TITLE
Remove </meta> to prevent IE10 from breaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 
   contentFor: function(type/*, config*/) {
     if (type === 'head-footer') {
-      return '<meta name="sentry:revision"></meta>';
+      return '<meta name="sentry:revision">';
     }
   },
 


### PR DESCRIPTION
This PR fixes a bug that occurs in IE10 as described here:
https://github.com/damiencaselli/ember-cli-sentry/issues/104