### PR TITLE
remove unnecessary usage of jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When you setup [raven-js][2] you can retrieve it like this:
 
 ```javascript
 Raven.config({
-    release: $("meta[name='sentry:revision']").attr('content')
+    release: document.querySelector("meta[name='sentry:revision']").content
 });
 ```
 

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -5,7 +5,7 @@ export default RavenService.extend({
     releaseMetaName: 'sentry:revision',
     release: Ember.computed('releaseMetaName', {
         get: function() {
-            return Ember.$(`meta[name='${this.get('releaseMetaName')}']`).attr('content');
+            return document.querySelector(`meta[name='${this.get('releaseMetaName')}']`).content;
         }
     })
 });


### PR DESCRIPTION
This unblocks usage of ember-cli-deploy-sentry in apps that don't bundle jQuery