### PR TITLE
Add urlPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ At deploy-time, the plugin will check your Sentry instance for an existing relea
 
 *Default* true
 
+### urlPrefix
+
+This sets a prefix to file names before uploading files to Sentry. This will overwrite `publicUrl` in the file name for your release's artifacts.
+
+i.e. If your assets are stored on Cloudfront, files would normally be named something like `https://xxxx.cloudfront.net/assets/...` in Sentry's release artifacts. If you set `urlPrefix` to `~`, files will instead be named `~/assets/...`
+
+*Default* Use `publicUrl`
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/index.js
+++ b/index.js
@@ -170,9 +170,14 @@ module.exports = {
       _uploadFile: function uploadFile(filePath) {
         var distDir = this.readConfig('distDir');
         var fileName = path.join(distDir, filePath);
+        var filePrefix = this.sentrySettings.publicUrl;
+
+        if (this.readConfig('urlPrefix')) {
+          filePrefix = this.readConfig('urlPrefix');
+        }
 
         var formData = {
-          name: urljoin(this.sentrySettings.publicUrl, filePath),
+          name: urljoin(filePrefix, filePath),
           file: fs.createReadStream(fileName),
         };
 

--- a/index.js
+++ b/index.js
@@ -170,11 +170,7 @@ module.exports = {
       _uploadFile: function uploadFile(filePath) {
         var distDir = this.readConfig('distDir');
         var fileName = path.join(distDir, filePath);
-        var filePrefix = this.sentrySettings.publicUrl;
-
-        if (this.readConfig('urlPrefix')) {
-          filePrefix = this.readConfig('urlPrefix');
-        }
+        var filePrefix = this._getFilePrefix();
 
         var formData = {
           name: urljoin(filePrefix, filePath),
@@ -188,6 +184,13 @@ module.exports = {
           formData: formData,
           strictSSL: this.readConfig('strictSSL'),
         });
+      },
+      _getFilePrefix: function() {
+        if (this.readConfig('urlPrefix')) {
+          return this.readConfig('urlPrefix');
+        }
+
+        return this.sentrySettings.publicUrl;
       },
       _getReleaseFiles: function getReleaseFiles() {
         return request({


### PR DESCRIPTION
Fixes #47 

Add `urlPrefix` option to replace `publicUrl` in the file name when uploading files to Sentry's release artifacts.

If the assets are stored on Cloudfront, files would normally be named something like `https://xxxx.cloudfront.net/assets/...` in Sentry's release artifacts. If you set `urlPrefix` to `~`, files will instead be named `~/assets/...`.