### PR TITLE
Make defaults clear in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The root directory that all files matching the `filePattern` will be uploaded fr
 ### revisionKey
 
 The revision string that is used to create releases in sentry.
+
+*Default:*
 ```javascript
   revisionKey: function(context) {
     return context.revisionData && context.revisionData.revisionKey;


### PR DESCRIPTION
The option `revisionKey` had example snippet in README. It was not clear whether it is default, or example syntax or what.