### PR TITLE
Make it obvious where to get the keys for hosted accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To get up and running quickly, do the following:
 $ ember install ember-cli-deploy-sentry
 ```
 
+- For hosted accounts, generate your bearer/api key here: https://sentry.io/api/
 - Place the following configuration into `config/deploy.js`
 
 ```javascript
@@ -31,7 +32,7 @@ ENV.sentry = {
   sentryUrl: 'https://sentry.your.awesome.site',
   sentryOrganizationSlug: 'AwesomeOrg',
   sentryProjectSlug: 'AwesomeProject',
-  // For hosted accounts, generate your bearer/api key here: https://sentry.io/api/
+  
   // One of:
   sentryApiKey: 'awesomeApiKey',
   // or


### PR DESCRIPTION
Sentry.io does not have the most straightforward settings and happened to me several times that I was trying to generate something called "deploy token" at the project level (which is IMO reasonable assumption). And it did not work. Only to find later on that the docs here actually give me hint where to obtain the key.

Somehow I always ignored the comment. This does not make it fool-proof, but IMO slightly more visible. So hopefully more people will have a success on the first go?