### PR TITLE
Add ability to associate a commit with a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ The revision string that is used to create releases in sentry.
   }
 ```
 
+### revisionCommits
+
+An array of revision commits allows us to associate commits with this Sentry release. See the [Sentry docs here](https://docs.sentry.io/workflow/releases/?platform=browser#using-the-api).
+
+*Default:*
+```javascript
+  revisionCommits: undefined
+```
+
+*Examples:*
+```javascript
+  revisionCommits: function(context) {
+    return [{
+      repository:"owner-name/repo-name", // required
+      id:"2da95dfb052f477380608d59d32b4ab9" // required
+    }]
+  }
+```
+
 ### enableRevisionTagging
 
 Enable adding a meta tag with the current revisionKey into the head of your `index.html`.

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -121,7 +121,7 @@ describe('deploySentry plugin', function() {
           return previous;
         }, []);
 
-        assert.equal(messages.length, 5);
+        assert.equal(messages.length, 6);
       });
 
       it('adds default config to the config object', function() {
@@ -145,6 +145,10 @@ describe('deploySentry plugin', function() {
         context.config.deploySentry["enableRevisionTagging"] = false;
         context.config.deploySentry["replaceFiles"] = true;
         context.config.deploySentry["strictSSL"] = true;
+        context.config.deploySentry["revisionCommits"] = [{
+          "repository":"owner-org/repo-name",
+          "id":"4c9c05d912292cb1b3e63c7947505cf19366c078"
+        }];
       });
 
       it('does not warn about missing optional config', function() {


### PR DESCRIPTION
Fixes https://github.com/dschmidt/ember-cli-deploy-sentry/issues/61

I've added a new config option `revisionCommits` which allows you to specify any commits which you'd like to associate with your release. This then means if you have the [Github Sentry Integration](https://sentry.io/integrations/github/) installed, commit information will appear in the Sentry UI.

By default the value is `undefined` but to get it working you need to have the property return an array of objects per commit in the following format:

```js
revisionCommits: function(context) {
  return [{
    repository:"owner-name/repo-name", // required
    id:"2da95dfb052f477380608d59d32b4ab9" // required
  }]
}
```

I'm currently running my fork in production and it's working as expected

![image](https://user-images.githubusercontent.com/685034/56414565-df1cfc00-6282-11e9-8ab4-80c614419449.png)
