### PR TITLE
Handle pagination when requesting release files from Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-deploy-plugin": "^0.2.0",
     "glob": "^5.0.14",
+    "parse-link-header": "^1.0.1",
     "request-promise": "^4.2.5",
     "silent-error": "^1.0.0",
     "throat": "^2.0.0",


### PR DESCRIPTION
Updating a release with a more than 100 files fails due to [pagination in the Sentry API](https://docs.sentry.io/api/pagination/).

Since only 100 files are deleted before re-uploading, a 409 response is returned when attempting up upload files that already exist.

I think this will fix #73 